### PR TITLE
add feature to support for LLVM 19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://danacus.gitlab.io/tblgen-rs/tblgen/"
 exclude = ["doc/"]
 
 [features]
-default = ["llvm19-0"]
+default = ["llvm18-0"]
 llvm16-0 = []
 llvm17-0 = []
 llvm18-0 = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,11 @@ documentation = "https://danacus.gitlab.io/tblgen-rs/tblgen/"
 exclude = ["doc/"]
 
 [features]
-default = ["llvm18-0"]
+default = ["llvm19-0"]
 llvm16-0 = []
 llvm17-0 = []
 llvm18-0 = []
+llvm19-0 = []
 
 [dependencies]
 thiserror = "1.0.61"

--- a/build.rs
+++ b/build.rs
@@ -12,6 +12,8 @@ const LLVM_MAJOR_VERSION: usize = 16;
 const LLVM_MAJOR_VERSION: usize = 17;
 #[cfg(feature = "llvm18-0")]
 const LLVM_MAJOR_VERSION: usize = 18;
+#[cfg(feature = "llvm19-0")]
+const LLVM_MAJOR_VERSION: usize = 19;
 
 fn main() {
     if let Err(error) = run() {

--- a/src/record_keeper.rs
+++ b/src/record_keeper.rs
@@ -10,7 +10,7 @@
 
 use std::marker::PhantomData;
 
-#[cfg(feature = "llvm18-0")]
+#[cfg(any(feature = "llvm18-0", feature = "llvm19-0"))]
 use crate::error::TableGenError;
 #[cfg(any(feature = "llvm16-0", feature = "llvm17-0"))]
 use crate::error::{SourceLocation, TableGenError, WithLocation};


### PR DESCRIPTION
Added support for llvm-19 major version, which will allow melior to bind to LLVM C API build from source to test changes. 