### PR TITLE
Conversion from invalid to string

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -521,7 +521,9 @@ mod tests {
     );
     test_init!(int, "int a = 42;", 42);
     test_init!(string, "string a = \"hi\";", "hi");
+    test_init!(invalid_string, "string a = ?;", "");
     test_init!(code, "code a = \"hi\";", "hi");
+    test_init!(invalid_code, "code a = ?;", "");
 
     #[test]
     fn dag() {


### PR DESCRIPTION
I'm not sure if this is a correct mapping. However, it's at least used in LLVM.

https://github.com/llvm/llvm-project/blob/93e860e694770f52a9eeecda88ba11173c291ef8/mlir/include/mlir/IR/CommonAttrConstraints.td#L31

```td
  code storageType = ?; // The backing mlir::Attribute type
```

The other option might be to treat `?` (invalid type) as `None` in Rust and all fields `Option`. But it's quite a bit of the API change...