### PR TITLE
Add From<BitsInit> for Vec<Option<bool>>

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -337,6 +337,14 @@ impl<'a> From<BitsInit<'a>> for Vec<bool> {
     }
 }
 
+impl<'a> From<BitsInit<'a>> for Vec<Option<bool>> {
+    fn from(value: BitsInit<'a>) -> Self {
+        (0..value.num_bits())
+            .map(|i| value.bit(i).expect("index within range").as_literal())
+            .collect()
+    }
+}
+
 impl<'a> BitsInit<'a> {
     /// Returns the bit at the given index.
     pub fn bit(self, index: usize) -> Option<BitInit<'a>> {
@@ -664,6 +672,8 @@ mod tests {
             assert_eq!(bit.as_var_bit(), Some(("Foo:src", i)));
             assert_eq!(bit.as_literal(), None);
         }
+        let optional: Vec<Option<bool>> = bits.into();
+        assert_eq!(optional, vec![None, None, None, None]);
     }
 
     #[test]


### PR DESCRIPTION
Closes #29.

`Vec<bool>::from(BitsInit)` panics when any bit is a `VarBitInit` (a variable reference like `s1{0}` that hasn't been resolved to a literal 0/1). There's no sensible `bool` value to return for an unresolved bit, so the conversion fails.

Adds `From<BitsInit> for Vec<Option<bool>>` where `None` means the bit is a variable reference. Callers can use this when iterating over bits from class templates or other contexts where not all bits are concrete literals.

The existing `Vec<bool>` conversion is unchanged.