### PR TITLE
Strip -D_FORTIFY_SOURCE from llvm-config flags in build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -119,9 +119,32 @@ fn run() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+fn filter_fortify_source(flags: &str) -> String {
+    flags
+        .split_whitespace()
+        .filter(|flag| !flag.starts_with("-D_FORTIFY_SOURCE"))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 fn build_c_library() -> Result<(), Box<dyn Error>> {
-    unsafe { env::set_var("CXXFLAGS", llvm_config(false, "--cxxflags")?) };
-    unsafe { env::set_var("CFLAGS", llvm_config(false, "--cflags")?) };
+    let raw_cxxflags = llvm_config(false, "--cxxflags")?;
+    let raw_cflags = llvm_config(false, "--cflags")?;
+
+    // The cc crate does not add -O when OPT_LEVEL=0, so -D_FORTIFY_SOURCE (which
+    // glibc requires to be paired with optimization) causes a #warning that
+    // -Werror turns into a hard error. Strip it only when compiling without
+    // optimization; otherwise keep it for the runtime hardening it provides.
+    let (cxxflags, cflags) = if env::var("OPT_LEVEL").as_deref() == Ok("0") {
+        (
+            filter_fortify_source(&raw_cxxflags),
+            filter_fortify_source(&raw_cflags),
+        )
+    } else {
+        (raw_cxxflags, raw_cflags)
+    };
+    unsafe { env::set_var("CXXFLAGS", cxxflags) };
+    unsafe { env::set_var("CFLAGS", cflags) };
 
     cc::Build::new()
         .cpp(true)


### PR DESCRIPTION
Fixes #27.

When LLVM is built with `-D_FORTIFY_SOURCE`, that flag gets baked into `llvm-config --cxxflags`. The build script passes those flags directly to `cc` via `CXXFLAGS`/`CFLAGS`, but the `cc` crate compiles without `-O` in debug builds. glibc headers require an optimization level when `_FORTIFY_SOURCE` is defined, so the implicit `-Werror` turns the resulting `#warning` into a hard build failure.

Adds `filter_fortify_source()` in `build.rs` to strip `-D_FORTIFY_SOURCE*` tokens from the llvm-config output before setting the env vars. Reproducible on NixOS with gcc 14 / glibc 2.40.