### PR TITLE
Fix soundness bugs and iterator memory leaks

### DIFF
--- a/cc/include/TableGen.h
+++ b/cc/include/TableGen.h
@@ -78,6 +78,7 @@ tableGenRecordKeeperGetAllDerivedDefinitions(TableGenRecordKeeperRef rk_ref,
 
 TableGenRecordRef tableGenRecordVectorGet(TableGenRecordVectorRef vec_ref,
                                           size_t index);
+size_t tableGenRecordVectorSize(TableGenRecordVectorRef vec_ref);
 void tableGenRecordVectorFree(TableGenRecordVectorRef vec_ref);
 
 TableGenRecordKeeperIteratorRef

--- a/cc/lib/Record.cpp
+++ b/cc/lib/Record.cpp
@@ -36,7 +36,11 @@ TableGenRecTyKind tableGenRecordGetFieldType(TableGenRecordRef record_ref,
 }
 
 TableGenRecordValRef tableGenRecordGetFirstValue(TableGenRecordRef record_ref) {
-  return wrap(unwrap(record_ref)->getValues().begin());
+  auto values = unwrap(record_ref)->getValues();
+  if (values.empty()) {
+    return nullptr;
+  }
+  return wrap(values.begin());
 }
 
 TableGenRecordValRef tableGenRecordValNext(TableGenRecordRef record,

--- a/cc/lib/RecordKeeper.cpp
+++ b/cc/lib/RecordKeeper.cpp
@@ -40,6 +40,7 @@ void tableGenRecordKeeperGetNextClass(TableGenRecordKeeperIteratorRef *item) {
   auto *it = unwrap(*item);
   auto end = (*it)->second->getRecords().getClasses().end();
   if (++*it == end) {
+    delete it;
     *item = nullptr;
   }
 }
@@ -48,6 +49,7 @@ void tableGenRecordKeeperGetNextDef(TableGenRecordKeeperIteratorRef *item) {
   auto *it = unwrap(*item);
   auto end = (*it)->second->getRecords().getDefs().end();
   if (++*it == end) {
+    delete it;
     *item = nullptr;
   }
 }
@@ -107,6 +109,10 @@ TableGenRecordRef tableGenRecordVectorGet(TableGenRecordVectorRef vec_ref,
   if (index < vec->size())
     return wrap(((*vec)[index]));
   return nullptr;
+}
+
+size_t tableGenRecordVectorSize(TableGenRecordVectorRef vec_ref) {
+  return unwrap(vec_ref)->size();
 }
 
 void tableGenRecordVectorFree(TableGenRecordVectorRef vec_ref) {

--- a/cc/lib/TableGen.cpp
+++ b/cc/lib/TableGen.cpp
@@ -17,7 +17,7 @@ using ctablegen::RecordMap;
 using ctablegen::tableGenFromRecType;
 
 RecordKeeper *ctablegen::TableGenParser::parse() {
-  auto recordKeeper = new RecordKeeper;
+  auto recordKeeper = std::unique_ptr<RecordKeeper>(new RecordKeeper);
   sourceMgr.setIncludeDirs(includeDirs);
 
   for (const auto &file : files) {
@@ -29,9 +29,8 @@ RecordKeeper *ctablegen::TableGenParser::parse() {
 
   bool result = TableGenParseFile(sourceMgr, *recordKeeper);
   if (!result) {
-    return recordKeeper;
+    return recordKeeper.release();
   }
-  delete recordKeeper;
   return nullptr;
 }
 

--- a/src/init.rs
+++ b/src/init.rs
@@ -311,11 +311,14 @@ impl<'a> BitInit<'a> {
     }
 }
 
-impl<'a> From<BitInit<'a>> for bool {
-    fn from(value: BitInit<'a>) -> Self {
-        value
-            .as_literal()
-            .expect("BitInit is a variable reference (VarBitInit), not a literal; use as_literal() or as_var_bit() instead")
+impl<'a> TryFrom<BitInit<'a>> for bool {
+    type Error = TableGenError;
+
+    fn try_from(value: BitInit<'a>) -> Result<Self, Self::Error> {
+        value.as_literal().ok_or(TableGenError::InitConversion {
+            from: "VarBitInit",
+            to: "bool",
+        })
     }
 }
 
@@ -329,10 +332,20 @@ impl<'a> From<BitsInit<'a>> for Vec<BitInit<'a>> {
     }
 }
 
-impl<'a> From<BitsInit<'a>> for Vec<bool> {
-    fn from(value: BitsInit<'a>) -> Self {
+impl<'a> TryFrom<BitsInit<'a>> for Vec<bool> {
+    type Error = TableGenError;
+
+    fn try_from(value: BitsInit<'a>) -> Result<Self, Self::Error> {
         (0..value.num_bits())
-            .map(|i| value.bit(i).expect("index within range").into())
+            .map(|i| {
+                value
+                    .bit(i)
+                    .ok_or(TableGenError::InitConversion {
+                        from: "BitsInit",
+                        to: "bool",
+                    })
+                    .and_then(bool::try_from)
+            })
             .collect()
     }
 }
@@ -366,12 +379,20 @@ impl<'a> BitsInit<'a> {
 
 init!(IntInit);
 
-impl<'a> From<IntInit<'a>> for i64 {
-    fn from(value: IntInit<'a>) -> Self {
+impl<'a> TryFrom<IntInit<'a>> for i64 {
+    type Error = TableGenError;
+
+    fn try_from(value: IntInit<'a>) -> Result<Self, Self::Error> {
         let mut int: i64 = 0;
         let res = unsafe { tableGenIntInitGetValue(value.raw, &mut int) };
-        assert!(res > 0);
-        int
+        if res > 0 {
+            Ok(int)
+        } else {
+            Err(TableGenError::InitConversion {
+                from: "Int",
+                to: "i64",
+            })
+        }
     }
 }
 
@@ -746,6 +767,50 @@ mod tests {
         }
         let optional: Vec<Option<bool>> = bits.into();
         assert_eq!(optional, vec![None, None, None, None]);
+    }
+
+    #[test]
+    fn vec_bool_from_varbit_bits_returns_err() {
+        // Variable-reference bits (VarBitInit) cannot be converted to bool.
+        // The TryFrom impl must return Err rather than panicking.
+        let rk = TableGenParser::new()
+            .add_source("class Foo<bits<4> src> { bits<4> val = src; }")
+            .unwrap()
+            .parse()
+            .expect("valid tablegen");
+        let bits: BitsInit = rk
+            .class("Foo")
+            .expect("class Foo exists")
+            .value("val")
+            .expect("field val exists")
+            .init
+            .as_bits()
+            .expect("is BitsInit");
+        let result = Vec::<bool>::try_from(bits);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn empty_list() {
+        let rk = TableGenParser::new()
+            .add_source("def A { list<int> l = []; }")
+            .unwrap()
+            .parse()
+            .expect("valid tablegen");
+        let l: ListInit = rk
+            .def("A")
+            .expect("def A exists")
+            .value("l")
+            .expect("field l exists")
+            .try_into()
+            .expect("is list init");
+        assert_eq!(l.len(), 0);
+        assert!(l.is_empty());
+        assert!(l.iter().next().is_none());
+        // Repeated next() calls on exhausted iterator must not misbehave.
+        let mut iter = l.iter();
+        assert!(iter.next().is_none());
+        assert!(iter.next().is_none());
     }
 
     #[test]

--- a/src/record.rs
+++ b/src/record.rs
@@ -300,13 +300,12 @@ impl<'a> Iterator for RecordValueIter<'a> {
     type Item = RecordValue<'a>;
 
     fn next(&mut self) -> Option<RecordValue<'a>> {
-        let res = if self.current.is_null() {
-            None
-        } else {
-            unsafe { Some(RecordValue::from_raw(self.current)) }
-        };
+        if self.current.is_null() {
+            return None;
+        }
+        let res = unsafe { RecordValue::from_raw(self.current) };
         self.current = unsafe { tableGenRecordValNext(self.record, self.current) };
-        res
+        Some(res)
     }
 }
 
@@ -369,7 +368,10 @@ mod tests {
                     assert!(v.name.to_str() == Ok("size"));
                     v.init.as_int().map_err(|e| e.set_location(v))
                 })
-                .map(|i| i.into()),
+                .and_then(|i| {
+                    i64::try_from(i)
+                        .map_err(|e| e.with_location(crate::error::SourceLocation::none()))
+                }),
             Ok(42)
         );
     }
@@ -395,7 +397,7 @@ mod tests {
             match v.init {
                 TypedInit::Int(i) => {
                     assert_eq!(v.name.to_str(), Ok("a"));
-                    assert_eq!(i64::from(i), 5);
+                    assert_eq!(i64::try_from(i).unwrap(), 5);
                 }
                 TypedInit::String(i) => {
                     assert_eq!(v.name.to_str(), Ok("n"));
@@ -404,6 +406,21 @@ mod tests {
                 _ => panic!("unexpected type"),
             }
         }
+    }
+
+    #[test]
+    fn empty_record_values() {
+        let rk = TableGenParser::new()
+            .add_source("def Empty;")
+            .unwrap()
+            .parse()
+            .expect("valid tablegen");
+        let r = rk.def("Empty").expect("def Empty exists");
+        assert_eq!(r.values().count(), 0);
+        // Calling next() on an already-exhausted iterator must not invoke UB.
+        let mut iter = r.values();
+        assert!(iter.next().is_none());
+        assert!(iter.next().is_none());
     }
 
     #[test]

--- a/src/record_keeper.rs
+++ b/src/record_keeper.rs
@@ -29,7 +29,7 @@ use crate::{
         tableGenRecordKeeperGetNextClass, tableGenRecordKeeperGetNextDef,
         tableGenRecordKeeperItemGetName, tableGenRecordKeeperItemGetRecord,
         tableGenRecordKeeperIteratorClone, tableGenRecordKeeperIteratorFree,
-        tableGenRecordVectorFree, tableGenRecordVectorGet,
+        tableGenRecordVectorFree, tableGenRecordVectorGet, tableGenRecordVectorSize,
     },
     record::Record,
     string_ref::StringRef,
@@ -173,6 +173,12 @@ impl<'a, T: NextRecord> Iterator for NamedRecordIter<'a, T> {
 
 impl<T> Clone for NamedRecordIter<'_, T> {
     fn clone(&self) -> Self {
+        if self.raw.is_null() {
+            return Self {
+                raw: std::ptr::null_mut(),
+                _kind: PhantomData,
+            };
+        }
         unsafe { Self::from_raw(tableGenRecordKeeperIteratorClone(self.raw)) }
     }
 }
@@ -186,14 +192,17 @@ impl<T> Drop for NamedRecordIter<'_, T> {
 pub struct RecordIter<'a> {
     raw: TableGenRecordVectorRef,
     index: usize,
+    len: usize,
     _reference: PhantomData<&'a ()>,
 }
 
 impl<'a> RecordIter<'a> {
     unsafe fn from_raw_vector(ptr: TableGenRecordVectorRef) -> RecordIter<'a> {
+        let len = unsafe { tableGenRecordVectorSize(ptr) };
         RecordIter {
             raw: ptr,
             index: 0,
+            len,
             _reference: PhantomData,
         }
     }
@@ -203,6 +212,9 @@ impl<'a> Iterator for RecordIter<'a> {
     type Item = Record<'a>;
 
     fn next(&mut self) -> Option<Record<'a>> {
+        if self.index >= self.len {
+            return None;
+        }
         let next = unsafe { tableGenRecordVectorGet(self.raw, self.index) };
         self.index += 1;
         if next.is_null() {
@@ -211,7 +223,14 @@ impl<'a> Iterator for RecordIter<'a> {
             unsafe { Some(Record::from_raw(next)) }
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.len.saturating_sub(self.index);
+        (remaining, Some(remaining))
+    }
 }
+
+impl ExactSizeIterator for RecordIter<'_> {}
 
 impl Drop for RecordIter<'_> {
     fn drop(&mut self) {
@@ -284,5 +303,63 @@ mod test {
             .expect("valid tablegen");
         assert_eq!(rk.class("A").expect("class exists").name().unwrap(), "A");
         assert_eq!(rk.def("D1").expect("def exists").name().unwrap(), "D1");
+    }
+
+    #[test]
+    fn clone_exhausted_named_iter() {
+        let rk = TableGenParser::new()
+            .add_source("class A; class B;")
+            .unwrap()
+            .parse()
+            .expect("valid tablegen");
+        let mut it = rk.classes();
+        while it.next().is_some() {}
+        // Must not segfault when cloning an exhausted iterator.
+        let mut cloned = it.clone();
+        assert!(cloned.next().is_none());
+    }
+
+    #[test]
+    fn empty_classes_and_defs() {
+        let rk = TableGenParser::new()
+            .add_source("// empty")
+            .unwrap()
+            .parse()
+            .expect("valid tablegen");
+        assert_eq!(rk.classes().count(), 0);
+        assert_eq!(rk.defs().count(), 0);
+    }
+
+    #[test]
+    fn record_iter_size_hint() {
+        let rk = TableGenParser::new()
+            .add_source(
+                r#"
+                class A;
+                def D1: A;
+                def D2: A;
+                def D3: A;
+                "#,
+            )
+            .unwrap()
+            .parse()
+            .expect("valid tablegen");
+        let mut iter = rk.all_derived_definitions("A");
+        assert_eq!(iter.size_hint(), (3, Some(3)));
+        assert_eq!(iter.len(), 3);
+        iter.next();
+        assert_eq!(iter.size_hint(), (2, Some(2)));
+        iter.next();
+        assert_eq!(iter.size_hint(), (1, Some(1)));
+        iter.next();
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+        assert!(iter.next().is_none());
+        assert_eq!(iter.size_hint(), (0, Some(0)));
+    }
+
+    #[test]
+    fn add_source_interior_null() {
+        let result = TableGenParser::new().add_source("def A;\0invalid");
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
**C++ layer:** `tableGenRecordGetFirstValue` returned a one-past-end pointer for empty records; now returns `nullptr`. `parse()` leaked the `RecordKeeper` allocation on failed file inclusion; switched to `unique_ptr`. `GetNextClass` and `GetNextDef` leaked the heap-allocated iterator before nulling the pointer; now `delete` before null. Added `tableGenRecordVectorSize` to support `ExactSizeIterator` on the Rust side.

**Rust layer:** `RecordValueIter::next()` called `tableGenRecordValNext` with a null pointer when the iterator was exhausted; early-return guards this. `NamedRecordIter::clone()` segfaulted on an exhausted iterator (null raw pointer); now returns a null iterator directly. `From<BitInit> for bool`, `From<BitsInit> for Vec<bool>`, and `From<IntInit> for i64` panicked on non-literal inits; replaced with `TryFrom` returning `TableGenError::InitConversion`. `RecordIter` gains `size_hint` and `ExactSizeIterator` via the new FFI call.

7 new tests cover the fixed cases: `clone_exhausted_named_iter`, `empty_classes_and_defs`, `record_iter_size_hint`, `add_source_interior_null`, `empty_record_values`, `vec_bool_from_varbit_bits_returns_err`, `empty_list`.