### PR TITLE
Fix header-hygiene in TableGen.hpp

### DIFF
--- a/cc/lib/Record.cpp
+++ b/cc/lib/Record.cpp
@@ -11,6 +11,7 @@
 #include "TableGen.hpp"
 #include "Types.h"
 
+using namespace llvm;
 using ctablegen::tableGenFromRecType;
 
 TableGenRecordKeeperRef tableGenRecordGetRecords(TableGenRecordRef record_ref) {

--- a/cc/lib/RecordKeeper.cpp
+++ b/cc/lib/RecordKeeper.cpp
@@ -11,6 +11,7 @@
 #include "TableGen.hpp"
 #include "Types.h"
 
+using namespace llvm;
 using ctablegen::RecordMap;
 
 void tableGenRecordKeeperFree(TableGenRecordKeeperRef rk_ref) {

--- a/cc/lib/RecordVal.cpp
+++ b/cc/lib/RecordVal.cpp
@@ -12,6 +12,8 @@
 #include "TableGen.hpp"
 #include "Types.h"
 
+using namespace llvm;
+
 TableGenStringRef tableGenRecordValGetName(TableGenRecordValRef rv_ref) {
   auto s = unwrap(rv_ref)->getName();
   return TableGenStringRef{.data = s.data(), .len = s.size()};

--- a/cc/lib/TableGen.cpp
+++ b/cc/lib/TableGen.cpp
@@ -13,6 +13,7 @@
 #include "Types.h"
 #include <cstring>
 
+using namespace llvm;
 using ctablegen::RecordMap;
 using ctablegen::tableGenFromRecType;
 

--- a/cc/lib/TableGen.hpp
+++ b/cc/lib/TableGen.hpp
@@ -26,23 +26,22 @@
 #include "Types.h"
 #include "llvm/Support/CBindingWrapping.h"
 
-using namespace llvm;
-
 namespace ctablegen {
 
-typedef std::map<std::string, std::unique_ptr<Record>, std::less<>> RecordMap;
-typedef std::vector<const Record *> RecordVector;
-typedef std::pair<std::string, TypedInit *> DagPair;
+typedef std::map<std::string, std::unique_ptr<llvm::Record>, std::less<>>
+    RecordMap;
+typedef std::vector<const llvm::Record *> RecordVector;
+typedef std::pair<std::string, llvm::TypedInit *> DagPair;
 
 class TableGenParser {
 public:
   TableGenParser() {}
   bool addSource(const char *source);
-  void addSourceFile(const StringRef source);
-  void addIncludeDirectory(const StringRef include);
-  RecordKeeper *parse();
+  void addSourceFile(const llvm::StringRef source);
+  void addIncludeDirectory(const llvm::StringRef include);
+  llvm::RecordKeeper *parse();
 
-  SourceMgr sourceMgr;
+  llvm::SourceMgr sourceMgr;
 
 private:
   std::vector<std::string> includeDirs;
@@ -50,7 +49,7 @@ private:
 };
 
 // Utility
-TableGenRecTyKind tableGenFromRecType(const RecTy *rt);
+TableGenRecTyKind tableGenFromRecType(const llvm::RecTy *rt);
 
 /// A simple raw ostream subclass that forwards write_impl calls to the
 /// user-supplied callback together with opaque user-supplied data.
@@ -79,24 +78,26 @@ private:
 
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(ctablegen::TableGenParser,
                                    TableGenParserRef);
-DEFINE_SIMPLE_CONVERSION_FUNCTIONS(RecordKeeper, TableGenRecordKeeperRef);
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(llvm::RecordKeeper, TableGenRecordKeeperRef);
 
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(ctablegen::RecordMap, TableGenRecordMapRef);
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(ctablegen::RecordVector,
                                    TableGenRecordVectorRef);
-DEFINE_SIMPLE_CONVERSION_FUNCTIONS(ArrayRef<Record>, TableGenRecordArrayRef);
-DEFINE_SIMPLE_CONVERSION_FUNCTIONS(ArrayRef<RecordVal>,
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(llvm::ArrayRef<llvm::Record>,
+                                   TableGenRecordArrayRef);
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(llvm::ArrayRef<llvm::RecordVal>,
                                    TableGenRecordValArrayRef);
 
-DEFINE_SIMPLE_CONVERSION_FUNCTIONS(Record, TableGenRecordRef);
-DEFINE_SIMPLE_CONVERSION_FUNCTIONS(RecordVal, TableGenRecordValRef);
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(llvm::Record, TableGenRecordRef);
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(llvm::RecordVal, TableGenRecordValRef);
 
-DEFINE_SIMPLE_CONVERSION_FUNCTIONS(TypedInit, TableGenTypedInitRef);
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(llvm::TypedInit, TableGenTypedInitRef);
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(ctablegen::DagPair, TableGenDagPairRef);
 
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(ctablegen::RecordMap::const_iterator,
                                    TableGenRecordKeeperIteratorRef);
 
-DEFINE_SIMPLE_CONVERSION_FUNCTIONS(ArrayRef<SMLoc>, TableGenSourceLocationRef);
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(llvm::ArrayRef<llvm::SMLoc>,
+                                   TableGenSourceLocationRef);
 
 #endif

--- a/cc/lib/Utility.cpp
+++ b/cc/lib/Utility.cpp
@@ -13,6 +13,8 @@
 #include "Types.h"
 #include "llvm/Support/SourceMgr.h"
 
+using namespace llvm;
+
 namespace ctablegen {
 
 TableGenRecTyKind tableGenFromRecType(const RecTy *rt) {


### PR DESCRIPTION
Without this, due to the use of `-Werror` in build.rs, `tblgen` fails to compile when `-Wheader-hygiene` is enforced by the build system or environment.

https://github.com/mlir-rs/tblgen-rs/blob/e7df21592d9954fb691cd1b0eff733481cc1089f/build.rs#L160-L164

Example: `CXX=clang++-21 CXXFLAGS_x86_64_unknown_linux_gnu=-Wheader-hygiene cargo check`

```console
error: failed to run custom build command for `tblgen v0.8.0`

Caused by:
  process didn't exit successfully: `target/debug/build/tblgen-752de26a660bb691/build-script-build` (exit status: 1)
  --- stdout
  cargo:rerun-if-changed=wrapper.h
  cargo:rerun-if-changed=cc
  cargo:rustc-link-search=/usr/lib/llvm-21/lib
  OPT_LEVEL = Some(0)
  TARGET = Some(x86_64-unknown-linux-gnu)
  CARGO_ENCODED_RUSTFLAGS = Some()
  HOST = Some(x86_64-unknown-linux-gnu)
  cargo:rerun-if-env-changed=CXX_x86_64-unknown-linux-gnu
  CXX_x86_64-unknown-linux-gnu = None
  cargo:rerun-if-env-changed=CXX_x86_64_unknown_linux_gnu
  CXX_x86_64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=HOST_CXX
  HOST_CXX = None
  cargo:rerun-if-env-changed=CXX
  CXX = Some(clang++-21)
  cargo:rerun-if-env-changed=CC_KNOWN_WRAPPER_CUSTOM
  CC_KNOWN_WRAPPER_CUSTOM = None
  RUSTC_WRAPPER = None
  cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  DEBUG = Some(true)
  cargo:rerun-if-env-changed=CXXFLAGS
  CXXFLAGS = Some(-I/usr/lib/llvm-21/include -std=c++17 -fno-exceptions -funwind-tables -D_GNU_SOURCE -DEXPERIMENTAL_KEY_INSTRUCTIONS -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS)
  cargo:rerun-if-env-changed=CC_SHELL_ESCAPED_FLAGS
  CC_SHELL_ESCAPED_FLAGS = None
  cargo:rerun-if-env-changed=HOST_CXXFLAGS
  HOST_CXXFLAGS = None
  cargo:rerun-if-env-changed=CXXFLAGS_x86_64_unknown_linux_gnu
  CXXFLAGS_x86_64_unknown_linux_gnu = Some(-Wheader-hygiene)
  cargo:rerun-if-env-changed=CXXFLAGS_x86_64-unknown-linux-gnu
  CXXFLAGS_x86_64-unknown-linux-gnu = None
  cargo:warning=In file included from cc/lib/RecordVal.cpp:12:
  cargo:warning=cc/lib/TableGen.hpp:29:17: error: using namespace directive in global context in header [-Werror,-Wheader-hygiene]
  cargo:warning=   29 | using namespace llvm;
  cargo:warning=      |                 ^
  cargo:warning=1 error generated.

  --- stderr

  error occurred in cc-rs: command did not execute successfully (status code exit status: 1): LC_ALL="C" "clang++-21" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-g" "-gdwarf-4" "-fno-omit-frame-pointer" "-m64" "--target=x86_64-unknown-linux-gnu" "-std=c++17" "-I" "cc/include" "-I" "/usr/lib/llvm-21/include" "-Werror" "-I/usr/lib/llvm-21/include" "-std=c++17" "-fno-exceptions" "-funwind-tables" "-D_GNU_SOURCE" "-DEXPERIMENTAL_KEY_INSTRUCTIONS" "-D__STDC_CONSTANT_MACROS" "-D__STDC_FORMAT_MACROS" "-D__STDC_LIMIT_MACROS" "-Wheader-hygiene" "-o" "target/debug/build/tblgen-8f49571c7a885ede/out/eaa0b8528c4d35fb-RecordVal.o" "-c" "cc/lib/RecordVal.cpp"
```