### PR TITLE
Fix soundness bugs and extend API coverage for 0.8.1

### DIFF
--- a/cc/include/TableGen.h
+++ b/cc/include/TableGen.h
@@ -75,6 +75,8 @@ TableGenRecordRef tableGenRecordKeeperGetDef(TableGenRecordKeeperRef rk_ref,
 TableGenRecordVectorRef
 tableGenRecordKeeperGetAllDerivedDefinitions(TableGenRecordKeeperRef rk_ref,
                                              TableGenStringRef className);
+TableGenRecordVectorRef tableGenRecordKeeperGetAllDerivedDefinitionsIfDefined(
+    TableGenRecordKeeperRef rk_ref, TableGenStringRef className);
 
 TableGenRecordRef tableGenRecordVectorGet(TableGenRecordVectorRef vec_ref,
                                           size_t index);
@@ -112,6 +114,12 @@ void tableGenRecordPrint(TableGenRecordRef record_ref,
                          TableGenStringCallback callback, void *userData);
 void tableGenRecordDump(TableGenRecordRef record_ref);
 TableGenSourceLocationRef tableGenRecordGetLoc(TableGenRecordRef record_ref);
+size_t tableGenRecordGetNumTemplateArgs(TableGenRecordRef record_ref);
+TableGenStringRef tableGenRecordGetTemplateArgName(TableGenRecordRef record_ref,
+                                                   size_t index);
+size_t tableGenRecordGetNumSuperClasses(TableGenRecordRef record_ref);
+TableGenRecordRef tableGenRecordGetSuperClass(TableGenRecordRef record_ref,
+                                              size_t index);
 
 // LLVM RecordVal
 TableGenStringRef tableGenRecordValGetName(TableGenRecordValRef rv_ref);
@@ -130,10 +138,8 @@ TableGenSourceLocationRef tableGenRecordValGetLoc(TableGenRecordValRef rv_ref);
 char *tableGenRecordValGetValAsNewString(TableGenRecordValRef rv_ref);
 TableGenBool tableGenRecordValGetValAsBit(TableGenRecordValRef rv_ref,
                                           int8_t *bit);
-int8_t *tableGenRecordValGetValAsBits(TableGenRecordValRef rv_ref, size_t *len);
 TableGenBool tableGenRecordValGetValAsInt(TableGenRecordValRef rv_ref,
                                           int64_t *integer);
-TableGenRecordRef tableGenRecordValGetValAsRecord(TableGenRecordValRef rv_ref);
 TableGenRecordRef
 tableGenRecordValGetValAsDefRecord(TableGenRecordValRef rv_ref);
 
@@ -142,6 +148,7 @@ TableGenRecTyKind tableGenListRecordGetType(TableGenRecordValRef rv_ref);
 TableGenTypedInitRef tableGenListRecordGet(TableGenTypedInitRef rv_ref,
                                            size_t index);
 size_t tableGenListRecordNumElements(TableGenTypedInitRef rv_ref);
+TableGenRecTyKind tableGenListInitGetElementType(TableGenTypedInitRef ti);
 
 // LLVM DagType
 TableGenRecordRef tableGenDagRecordOperator(TableGenTypedInitRef rv_ref);
@@ -154,7 +161,6 @@ size_t tableGenDagRecordNumArgs(TableGenTypedInitRef rv_ref);
 // Utility
 TableGenRecTyKind tableGenInitRecType(TableGenTypedInitRef ti);
 TableGenBool tableGenBitInitGetValue(TableGenTypedInitRef ti, int8_t *bit);
-int8_t *tableGenBitsInitGetValue(TableGenTypedInitRef ti, size_t *len);
 TableGenBool tableGenBitsInitGetNumBits(TableGenTypedInitRef ti, size_t *len);
 TableGenTypedInitRef tableGenBitsInitGetBitInit(TableGenTypedInitRef ti,
                                                 size_t index);
@@ -181,7 +187,6 @@ size_t tableGenVarBitInitGetBitNum(TableGenTypedInitRef ti);
 
 // Memory
 void tableGenSourceLocationFree(TableGenSourceLocationRef loc_ref);
-void tableGenBitArrayFree(int8_t bit_array[]);
 void tableGenStringFree(const char *str);
 void tableGenStringArrayFree(const char **str_array);
 

--- a/cc/lib/Record.cpp
+++ b/cc/lib/Record.cpp
@@ -10,6 +10,7 @@
 
 #include "TableGen.hpp"
 #include "Types.h"
+#include <llvm/Config/llvm-config.h>
 
 using namespace llvm;
 using ctablegen::tableGenFromRecType;
@@ -74,4 +75,40 @@ void tableGenRecordPrint(TableGenRecordRef record_ref,
 
 void tableGenRecordDump(TableGenRecordRef record_ref) {
   unwrap(record_ref)->dump();
+}
+
+size_t tableGenRecordGetNumTemplateArgs(TableGenRecordRef record_ref) {
+  return unwrap(record_ref)->getTemplateArgs().size();
+}
+
+TableGenStringRef tableGenRecordGetTemplateArgName(TableGenRecordRef record_ref,
+                                                   size_t index) {
+  auto args = unwrap(record_ref)->getTemplateArgs();
+  if (index >= args.size())
+    return TableGenStringRef{.data = nullptr, .len = 0};
+  auto name = dyn_cast<StringInit>(args[index]);
+  if (!name)
+    return TableGenStringRef{.data = nullptr, .len = 0};
+  auto val = name->getValue();
+  return TableGenStringRef{.data = val.data(), .len = val.size()};
+}
+
+size_t tableGenRecordGetNumSuperClasses(TableGenRecordRef record_ref) {
+#if LLVM_VERSION_MAJOR >= 21
+  return unwrap(record_ref)->getDirectSuperClasses().size();
+#else
+  return unwrap(record_ref)->getSuperClasses().size();
+#endif
+}
+
+TableGenRecordRef tableGenRecordGetSuperClass(TableGenRecordRef record_ref,
+                                              size_t index) {
+#if LLVM_VERSION_MAJOR >= 21
+  auto supers = unwrap(record_ref)->getDirectSuperClasses();
+#else
+  auto supers = unwrap(record_ref)->getSuperClasses();
+#endif
+  if (index >= supers.size())
+    return nullptr;
+  return wrap(supers[index].first);
 }

--- a/cc/lib/RecordKeeper.cpp
+++ b/cc/lib/RecordKeeper.cpp
@@ -20,37 +20,32 @@ void tableGenRecordKeeperFree(TableGenRecordKeeperRef rk_ref) {
 
 TableGenRecordKeeperIteratorRef
 tableGenRecordKeeperGetFirstClass(TableGenRecordKeeperRef rk_ref) {
-  auto *it =
-      new RecordMap::const_iterator(unwrap(rk_ref)->getClasses().begin());
-  if (*it == unwrap(rk_ref)->getClasses().end()) {
+  auto &classes = unwrap(rk_ref)->getClasses();
+  if (classes.begin() == classes.end())
     return nullptr;
-  }
-  return wrap(it);
+  return wrap(new ctablegen::RecordMapIterator{classes.begin(), classes.end()});
 }
 
 TableGenRecordKeeperIteratorRef
 tableGenRecordKeeperGetFirstDef(TableGenRecordKeeperRef rk_ref) {
-  auto *it = new RecordMap::const_iterator(unwrap(rk_ref)->getDefs().begin());
-  if (*it == unwrap(rk_ref)->getDefs().end()) {
+  auto &defs = unwrap(rk_ref)->getDefs();
+  if (defs.begin() == defs.end())
     return nullptr;
-  }
-  return wrap(it);
+  return wrap(new ctablegen::RecordMapIterator{defs.begin(), defs.end()});
 }
 
 void tableGenRecordKeeperGetNextClass(TableGenRecordKeeperIteratorRef *item) {
-  auto *it = unwrap(*item);
-  auto end = (*it)->second->getRecords().getClasses().end();
-  if (++*it == end) {
-    delete it;
+  auto *iter = unwrap(*item);
+  if (++iter->it == iter->end) {
+    delete iter;
     *item = nullptr;
   }
 }
 
 void tableGenRecordKeeperGetNextDef(TableGenRecordKeeperIteratorRef *item) {
-  auto *it = unwrap(*item);
-  auto end = (*it)->second->getRecords().getDefs().end();
-  if (++*it == end) {
-    delete it;
+  auto *iter = unwrap(*item);
+  if (++iter->it == iter->end) {
+    delete iter;
     *item = nullptr;
   }
 }
@@ -62,18 +57,19 @@ void tableGenRecordKeeperIteratorFree(TableGenRecordKeeperIteratorRef item) {
 
 TableGenRecordKeeperIteratorRef
 tableGenRecordKeeperIteratorClone(TableGenRecordKeeperIteratorRef item) {
-  return wrap(new RecordMap::const_iterator(*unwrap(item)));
+  auto *iter = unwrap(item);
+  return wrap(new ctablegen::RecordMapIterator{iter->it, iter->end});
 }
 
 TableGenStringRef
 tableGenRecordKeeperItemGetName(TableGenRecordKeeperIteratorRef item) {
-  auto &s = (*unwrap(item))->first;
+  auto &s = unwrap(item)->it->first;
   return TableGenStringRef{.data = s.data(), .len = s.size()};
 }
 
 TableGenRecordRef
 tableGenRecordKeeperItemGetRecord(TableGenRecordKeeperIteratorRef item) {
-  return wrap((*unwrap(item))->second.get());
+  return wrap(unwrap(item)->it->second.get());
 }
 
 TableGenRecordMapRef
@@ -118,4 +114,11 @@ size_t tableGenRecordVectorSize(TableGenRecordVectorRef vec_ref) {
 
 void tableGenRecordVectorFree(TableGenRecordVectorRef vec_ref) {
   delete unwrap(vec_ref);
+}
+
+TableGenRecordVectorRef tableGenRecordKeeperGetAllDerivedDefinitionsIfDefined(
+    TableGenRecordKeeperRef rk_ref, TableGenStringRef className) {
+  return wrap(new ctablegen::RecordVector(
+      unwrap(rk_ref)->getAllDerivedDefinitionsIfDefined(
+          StringRef(className.data, className.len))));
 }

--- a/cc/lib/RecordVal.cpp
+++ b/cc/lib/RecordVal.cpp
@@ -42,12 +42,6 @@ TableGenBool tableGenRecordValGetValAsBit(TableGenRecordValRef rv_ref,
       wrap(dyn_cast<TypedInit>(unwrap(rv_ref)->getValue())), bit);
 }
 
-int8_t *tableGenRecordValGetValAsBits(TableGenRecordValRef rv_ref,
-                                      size_t *len) {
-  return tableGenBitsInitGetValue(
-      wrap(dyn_cast<TypedInit>(unwrap(rv_ref)->getValue())), len);
-}
-
 TableGenBool tableGenRecordValGetValAsInt(TableGenRecordValRef rv_ref,
                                           int64_t *integer) {
   return tableGenIntInitGetValue(

--- a/cc/lib/TableGen.cpp
+++ b/cc/lib/TableGen.cpp
@@ -113,6 +113,18 @@ TableGenTypedInitRef tableGenListRecordGet(TableGenTypedInitRef rv_ref,
   return wrap(elem);
 }
 
+TableGenRecTyKind tableGenListInitGetElementType(TableGenTypedInitRef ti) {
+  if (!ti)
+    return TableGenInvalidRecTyKind;
+  auto list = dyn_cast<ListInit>(unwrap(ti));
+  if (!list)
+    return TableGenInvalidRecTyKind;
+  auto *listTy = dyn_cast<ListRecTy>(list->getType());
+  if (!listTy)
+    return TableGenInvalidRecTyKind;
+  return tableGenFromRecType(listTy->getElementType());
+}
+
 // LLVM DagType
 TableGenTypedInitRef tableGenDagRecordGet(TableGenTypedInitRef rv_ref,
                                           size_t index) {
@@ -153,8 +165,6 @@ TableGenStringRef tableGenDagRecordArgName(TableGenTypedInitRef rv_ref,
 }
 
 // Memory
-void tableGenBitArrayFree(int8_t bit_array[]) { delete[] bit_array; }
-
 void tableGenStringFree(const char *str) { delete str; }
 
 void tableGenStringArrayFree(const char **str_array) { delete str_array; }

--- a/cc/lib/TableGen.hpp
+++ b/cc/lib/TableGen.hpp
@@ -74,6 +74,11 @@ private:
   uint64_t pos;
 };
 
+struct RecordMapIterator {
+  RecordMap::const_iterator it;
+  RecordMap::const_iterator end;
+};
+
 } // namespace ctablegen
 
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(ctablegen::TableGenParser,
@@ -94,7 +99,7 @@ DEFINE_SIMPLE_CONVERSION_FUNCTIONS(llvm::RecordVal, TableGenRecordValRef);
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(llvm::TypedInit, TableGenTypedInitRef);
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(ctablegen::DagPair, TableGenDagPairRef);
 
-DEFINE_SIMPLE_CONVERSION_FUNCTIONS(ctablegen::RecordMap::const_iterator,
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(ctablegen::RecordMapIterator,
                                    TableGenRecordKeeperIteratorRef);
 
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(llvm::ArrayRef<llvm::SMLoc>,

--- a/cc/lib/Utility.cpp
+++ b/cc/lib/Utility.cpp
@@ -59,24 +59,6 @@ TableGenBool tableGenBitInitGetValue(TableGenTypedInitRef ti, int8_t *bit) {
   return true;
 }
 
-int8_t *tableGenBitsInitGetValue(TableGenTypedInitRef ti, size_t *len) {
-  if (!ti)
-    return nullptr;
-  auto bits_init = dyn_cast<BitsInit>(unwrap(ti));
-  if (!bits_init)
-    return nullptr;
-
-  *len = bits_init->getNumBits();
-  auto bits = new int8_t[*len];
-
-  for (size_t i = 0; i < *len; i++) {
-    bits[i] =
-        reinterpret_cast<const BitInit *>(bits_init->getBit(i))->getValue();
-  }
-
-  return bits;
-}
-
 TableGenBool tableGenBitsInitGetNumBits(TableGenTypedInitRef ti, size_t *len) {
   if (!ti)
     return false;

--- a/src/init.rs
+++ b/src/init.rs
@@ -21,8 +21,9 @@ use crate::{
         tableGenBitsInitGetBitInit, tableGenBitsInitGetNumBits, tableGenDagRecordArgName,
         tableGenDagRecordGet, tableGenDagRecordNumArgs, tableGenDagRecordOperator,
         tableGenDefInitGetValue, tableGenInitDump, tableGenInitPrint, tableGenInitRecType,
-        tableGenIntInitGetValue, tableGenListRecordGet, tableGenListRecordNumElements,
-        tableGenStringInitGetValue, tableGenVarBitInitGetBitNum, tableGenVarBitInitGetVarName,
+        tableGenIntInitGetValue, tableGenListInitGetElementType, tableGenListRecordGet,
+        tableGenListRecordNumElements, tableGenStringInitGetValue, tableGenVarBitInitGetBitNum,
+        tableGenVarBitInitGetVarName,
     },
     string_ref::StringRef,
     util::print_callback,
@@ -596,6 +597,17 @@ impl<'a> ListInit<'a> {
             None
         }
     }
+
+    /// Returns the element type of this list, or `None` if it cannot be determined.
+    pub fn element_type(self) -> Option<crate::raw::TableGenRecTyKind::Type> {
+        use crate::raw::TableGenRecTyKind::TableGenInvalidRecTyKind;
+        let kind = unsafe { tableGenListInitGetElementType(self.raw) };
+        if kind == TableGenInvalidRecTyKind {
+            None
+        } else {
+            Some(kind)
+        }
+    }
 }
 
 /// Iterator over the elements of a [`ListInit`].
@@ -977,5 +989,33 @@ mod tests {
             assert!(bit.as_var_bit().is_none());
             assert!(bit.as_literal().is_some());
         }
+    }
+
+    #[test]
+    fn list_element_type() {
+        use crate::raw::TableGenRecTyKind::{
+            TableGenDagRecTyKind, TableGenIntRecTyKind, TableGenStringRecTyKind,
+        };
+        let rk = TableGenParser::new()
+            .add_source(
+                r#"
+                def op;
+                def A {
+                    list<int> li = [1, 2, 3];
+                    list<string> ls = ["a", "b"];
+                    list<dag> ld = [(op)];
+                }
+                "#,
+            )
+            .unwrap()
+            .parse()
+            .expect("valid tablegen");
+        let a = rk.def("A").expect("def A exists");
+        let li: ListInit = a.value("li").unwrap().try_into().unwrap();
+        assert_eq!(li.element_type(), Some(TableGenIntRecTyKind));
+        let ls: ListInit = a.value("ls").unwrap().try_into().unwrap();
+        assert_eq!(ls.element_type(), Some(TableGenStringRecTyKind));
+        let ld: ListInit = a.value("ld").unwrap().try_into().unwrap();
+        assert_eq!(ld.element_type(), Some(TableGenDagRecTyKind));
     }
 }

--- a/src/record.rs
+++ b/src/record.rs
@@ -14,10 +14,11 @@ use std::{ffi::c_void, marker::PhantomData};
 use crate::raw::{
     TableGenRecordRef, TableGenRecordValRef, tableGenRecordDump, tableGenRecordGetFieldType,
     tableGenRecordGetFirstValue, tableGenRecordGetLoc, tableGenRecordGetName,
-    tableGenRecordGetValue, tableGenRecordIsAnonymous, tableGenRecordIsSubclassOf,
-    tableGenRecordPrint, tableGenRecordValDump, tableGenRecordValGetLoc,
-    tableGenRecordValGetNameInit, tableGenRecordValGetValue, tableGenRecordValNext,
-    tableGenRecordValPrint,
+    tableGenRecordGetNumSuperClasses, tableGenRecordGetNumTemplateArgs,
+    tableGenRecordGetSuperClass, tableGenRecordGetTemplateArgName, tableGenRecordGetValue,
+    tableGenRecordIsAnonymous, tableGenRecordIsSubclassOf, tableGenRecordPrint,
+    tableGenRecordValDump, tableGenRecordValGetLoc, tableGenRecordValGetNameInit,
+    tableGenRecordValGetValue, tableGenRecordValNext, tableGenRecordValPrint,
 };
 
 use crate::{
@@ -220,6 +221,52 @@ impl<'a> Record<'a> {
     pub fn dump(self) {
         unsafe { tableGenRecordDump(self.raw) }
     }
+
+    /// Returns the number of template arguments.
+    pub fn num_template_args(self) -> usize {
+        unsafe { tableGenRecordGetNumTemplateArgs(self.raw) }
+    }
+
+    /// Returns the template argument name at the given index.
+    pub fn template_arg_name(self, index: usize) -> Option<&'a str> {
+        unsafe { StringRef::from_option_raw(tableGenRecordGetTemplateArgName(self.raw, index)) }
+            .and_then(|s| s.try_into().ok())
+    }
+
+    /// Returns an iterator over the template argument names.
+    pub fn template_args(self) -> TemplateArgIter<'a> {
+        let back = self.num_template_args();
+        TemplateArgIter {
+            record: self,
+            index: 0,
+            back,
+        }
+    }
+
+    /// Returns the number of direct super classes.
+    pub fn num_super_classes(self) -> usize {
+        unsafe { tableGenRecordGetNumSuperClasses(self.raw) }
+    }
+
+    /// Returns the super class at the given index.
+    pub fn super_class(self, index: usize) -> Option<Record<'a>> {
+        let ptr = unsafe { tableGenRecordGetSuperClass(self.raw, index) };
+        if ptr.is_null() {
+            None
+        } else {
+            Some(unsafe { Record::from_raw(ptr) })
+        }
+    }
+
+    /// Returns an iterator over the direct super classes.
+    pub fn direct_super_classes(self) -> SuperClassIter<'a> {
+        let back = self.num_super_classes();
+        SuperClassIter {
+            record: self,
+            index: 0,
+            back,
+        }
+    }
 }
 
 impl SourceLoc for Record<'_> {
@@ -352,6 +399,98 @@ impl<'a> Iterator for RecordValueIter<'a> {
 }
 
 impl std::iter::FusedIterator for RecordValueIter<'_> {}
+
+/// Iterator over the template argument names of a [`Record`].
+#[derive(Debug, Clone)]
+pub struct TemplateArgIter<'a> {
+    record: Record<'a>,
+    index: usize,
+    back: usize,
+}
+
+impl<'a> Iterator for TemplateArgIter<'a> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index >= self.back {
+            return None;
+        }
+        let name = self.record.template_arg_name(self.index);
+        self.index += 1;
+        name
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.back.saturating_sub(self.index);
+        (remaining, Some(remaining))
+    }
+}
+
+impl<'a> DoubleEndedIterator for TemplateArgIter<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.index >= self.back {
+            return None;
+        }
+        self.back -= 1;
+        match self.record.template_arg_name(self.back) {
+            Some(name) => Some(name),
+            None => {
+                self.back += 1;
+                None
+            }
+        }
+    }
+}
+
+impl ExactSizeIterator for TemplateArgIter<'_> {}
+
+impl std::iter::FusedIterator for TemplateArgIter<'_> {}
+
+/// Iterator over the direct super classes of a [`Record`].
+#[derive(Debug, Clone)]
+pub struct SuperClassIter<'a> {
+    record: Record<'a>,
+    index: usize,
+    back: usize,
+}
+
+impl<'a> Iterator for SuperClassIter<'a> {
+    type Item = Record<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index >= self.back {
+            return None;
+        }
+        let class = self.record.super_class(self.index);
+        self.index += 1;
+        class
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.back.saturating_sub(self.index);
+        (remaining, Some(remaining))
+    }
+}
+
+impl<'a> DoubleEndedIterator for SuperClassIter<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.index >= self.back {
+            return None;
+        }
+        self.back -= 1;
+        match self.record.super_class(self.back) {
+            Some(class) => Some(class),
+            None => {
+                self.back += 1;
+                None
+            }
+        }
+    }
+}
+
+impl ExactSizeIterator for SuperClassIter<'_> {}
+
+impl std::iter::FusedIterator for SuperClassIter<'_> {}
 
 #[cfg(test)]
 mod tests {
@@ -547,5 +686,162 @@ mod tests {
         assert_eq!(a.field_type("s"), Some(TableGenStringRecTyKind));
         assert_eq!(a.field_type("b"), Some(TableGenBitRecTyKind));
         assert_eq!(a.field_type("nonexistent"), None);
+    }
+
+    #[test]
+    fn template_args() {
+        let rk = TableGenParser::new()
+            .add_source("class Foo<int x, string y>;")
+            .unwrap()
+            .parse()
+            .expect("valid tablegen");
+        let foo = rk.class("Foo").expect("class Foo exists");
+        assert_eq!(foo.num_template_args(), 2);
+        assert_eq!(foo.template_arg_name(0), Some("Foo:x"));
+        assert_eq!(foo.template_arg_name(1), Some("Foo:y"));
+        assert_eq!(foo.template_arg_name(2), None);
+        let names: Vec<_> = foo.template_args().collect();
+        assert_eq!(names, vec!["Foo:x", "Foo:y"]);
+        // Double-ended
+        let mut iter = foo.template_args();
+        assert_eq!(iter.next_back(), Some("Foo:y"));
+        assert_eq!(iter.next(), Some("Foo:x"));
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn template_args_on_def() {
+        let rk = TableGenParser::new()
+            .add_source("class A; def D: A;")
+            .unwrap()
+            .parse()
+            .expect("valid tablegen");
+        let d = rk.def("D").expect("def D exists");
+        assert_eq!(d.num_template_args(), 0);
+        assert_eq!(d.template_arg_name(0), None);
+        assert_eq!(d.template_args().count(), 0);
+    }
+
+    #[test]
+    fn template_args_no_params() {
+        let rk = TableGenParser::new()
+            .add_source("class Foo;")
+            .unwrap()
+            .parse()
+            .expect("valid tablegen");
+        let foo = rk.class("Foo").expect("class Foo exists");
+        assert_eq!(foo.num_template_args(), 0);
+        assert_eq!(foo.template_args().count(), 0);
+        let mut iter = foo.template_args();
+        assert!(iter.next().is_none());
+        assert!(iter.next_back().is_none());
+    }
+
+    #[test]
+    fn template_args_len_tracks() {
+        let rk = TableGenParser::new()
+            .add_source("class Foo<int a, int b, int c>;")
+            .unwrap()
+            .parse()
+            .expect("valid tablegen");
+        let foo = rk.class("Foo").expect("class Foo exists");
+        let mut iter = foo.template_args();
+        assert_eq!(iter.len(), 3);
+        iter.next();
+        assert_eq!(iter.len(), 2);
+        iter.next_back();
+        assert_eq!(iter.len(), 1);
+        iter.next();
+        assert_eq!(iter.len(), 0);
+        assert!(iter.next().is_none());
+        assert!(iter.next_back().is_none());
+    }
+
+    #[test]
+    fn super_classes() {
+        let rk = TableGenParser::new()
+            .add_source(
+                r#"
+                class A;
+                class B;
+                class C;
+                def D: A, B, C;
+                "#,
+            )
+            .unwrap()
+            .parse()
+            .expect("valid tablegen");
+        let d = rk.def("D").expect("def D exists");
+        assert_eq!(d.num_super_classes(), 3);
+        assert_eq!(d.super_class(0).unwrap().name().unwrap(), "A");
+        assert_eq!(d.super_class(1).unwrap().name().unwrap(), "B");
+        assert_eq!(d.super_class(2).unwrap().name().unwrap(), "C");
+        assert!(d.super_class(3).is_none());
+        let names: Vec<_> = d
+            .direct_super_classes()
+            .map(|r| r.name().unwrap().to_string())
+            .collect();
+        assert_eq!(names, vec!["A", "B", "C"]);
+        // Double-ended
+        let mut iter = d.direct_super_classes();
+        assert_eq!(iter.next_back().unwrap().name().unwrap(), "C");
+        assert_eq!(iter.next().unwrap().name().unwrap(), "A");
+        assert_eq!(iter.next().unwrap().name().unwrap(), "B");
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn super_classes_on_class() {
+        let rk = TableGenParser::new()
+            .add_source("class A; class B: A; class C: A, B;")
+            .unwrap()
+            .parse()
+            .expect("valid tablegen");
+        let b = rk.class("B").expect("class B exists");
+        assert_eq!(b.num_super_classes(), 1);
+        assert_eq!(b.super_class(0).unwrap().name().unwrap(), "A");
+        let c = rk.class("C").expect("class C exists");
+        assert_eq!(c.num_super_classes(), 2);
+        let names: Vec<_> = c
+            .direct_super_classes()
+            .map(|r| r.name().unwrap().to_string())
+            .collect();
+        assert_eq!(names, vec!["A", "B"]);
+    }
+
+    #[test]
+    fn super_classes_empty() {
+        let rk = TableGenParser::new()
+            .add_source("def D;")
+            .unwrap()
+            .parse()
+            .expect("valid tablegen");
+        let d = rk.def("D").expect("def D exists");
+        assert_eq!(d.num_super_classes(), 0);
+        assert!(d.super_class(0).is_none());
+        assert_eq!(d.direct_super_classes().count(), 0);
+        let mut iter = d.direct_super_classes();
+        assert!(iter.next().is_none());
+        assert!(iter.next_back().is_none());
+    }
+
+    #[test]
+    fn super_classes_len_tracks() {
+        let rk = TableGenParser::new()
+            .add_source("class A; class B; class C; def D: A, B, C;")
+            .unwrap()
+            .parse()
+            .expect("valid tablegen");
+        let d = rk.def("D").expect("def D exists");
+        let mut iter = d.direct_super_classes();
+        assert_eq!(iter.len(), 3);
+        iter.next();
+        assert_eq!(iter.len(), 2);
+        iter.next_back();
+        assert_eq!(iter.len(), 1);
+        iter.next();
+        assert_eq!(iter.len(), 0);
+        assert!(iter.next().is_none());
+        assert!(iter.next_back().is_none());
     }
 }

--- a/src/record_keeper.rs
+++ b/src/record_keeper.rs
@@ -24,12 +24,13 @@ use crate::{
     raw::{
         TableGenRecordKeeperIteratorRef, TableGenRecordKeeperRef, TableGenRecordVectorRef,
         tableGenRecordKeeperFree, tableGenRecordKeeperGetAllDerivedDefinitions,
-        tableGenRecordKeeperGetClass, tableGenRecordKeeperGetDef,
-        tableGenRecordKeeperGetFirstClass, tableGenRecordKeeperGetFirstDef,
-        tableGenRecordKeeperGetNextClass, tableGenRecordKeeperGetNextDef,
-        tableGenRecordKeeperItemGetName, tableGenRecordKeeperItemGetRecord,
-        tableGenRecordKeeperIteratorClone, tableGenRecordKeeperIteratorFree,
-        tableGenRecordVectorFree, tableGenRecordVectorGet, tableGenRecordVectorSize,
+        tableGenRecordKeeperGetAllDerivedDefinitionsIfDefined, tableGenRecordKeeperGetClass,
+        tableGenRecordKeeperGetDef, tableGenRecordKeeperGetFirstClass,
+        tableGenRecordKeeperGetFirstDef, tableGenRecordKeeperGetNextClass,
+        tableGenRecordKeeperGetNextDef, tableGenRecordKeeperItemGetName,
+        tableGenRecordKeeperItemGetRecord, tableGenRecordKeeperIteratorClone,
+        tableGenRecordKeeperIteratorFree, tableGenRecordVectorFree, tableGenRecordVectorGet,
+        tableGenRecordVectorSize,
     },
     record::Record,
     string_ref::StringRef,
@@ -93,6 +94,17 @@ impl<'s> RecordKeeper<'s> {
     pub fn all_derived_definitions(&self, name: &str) -> RecordIter<'_> {
         unsafe {
             RecordIter::from_raw_vector(tableGenRecordKeeperGetAllDerivedDefinitions(
+                self.raw,
+                StringRef::from(name).to_raw(),
+            ))
+        }
+    }
+
+    /// Returns an iterator over all definitions that derive from the class with
+    /// the given name. Returns an empty iterator if the class is not defined.
+    pub fn all_derived_definitions_if_defined(&self, name: &str) -> RecordIter<'_> {
+        unsafe {
+            RecordIter::from_raw_vector(tableGenRecordKeeperGetAllDerivedDefinitionsIfDefined(
                 self.raw,
                 StringRef::from(name).to_raw(),
             ))
@@ -390,6 +402,61 @@ mod test {
     fn add_source_interior_null() {
         let result = TableGenParser::new().add_source("def A;\0invalid");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn derived_defs_if_defined_empty_results() {
+        let rk = TableGenParser::new()
+            .add_source("class A; class B; def D1: A;")
+            .unwrap()
+            .parse()
+            .expect("valid tablegen");
+        // B exists but nothing derives from it
+        let b = rk.all_derived_definitions_if_defined("B");
+        assert_eq!(b.count(), 0);
+    }
+
+    #[test]
+    fn named_iter_clone_mid_iteration() {
+        let rk = TableGenParser::new()
+            .add_source("class A; class B; class C;")
+            .unwrap()
+            .parse()
+            .expect("valid tablegen");
+        let mut iter = rk.classes();
+        assert_eq!(iter.next().unwrap().0, Ok("A"));
+        // Clone mid-iteration; both should continue independently
+        let mut cloned = iter.clone();
+        assert_eq!(iter.next().unwrap().0, Ok("B"));
+        assert_eq!(cloned.next().unwrap().0, Ok("B"));
+        assert_eq!(iter.next().unwrap().0, Ok("C"));
+        assert_eq!(cloned.next().unwrap().0, Ok("C"));
+        assert!(iter.next().is_none());
+        assert!(cloned.next().is_none());
+    }
+
+    #[test]
+    fn derived_defs_if_defined() {
+        let rk = TableGenParser::new()
+            .add_source(
+                r#"
+                class A;
+                def D1: A;
+                def D2: A;
+                "#,
+            )
+            .unwrap()
+            .parse()
+            .expect("valid tablegen");
+        // Existing class
+        let a = rk.all_derived_definitions_if_defined("A");
+        assert_eq!(
+            a.map(|r| r.name().unwrap().to_string()).collect::<Vec<_>>(),
+            vec!["D1", "D2"]
+        );
+        // Non-existing class returns empty
+        let b = rk.all_derived_definitions_if_defined("NonExistent");
+        assert_eq!(b.count(), 0);
     }
 
     #[test]


### PR DESCRIPTION
Three dead/unsound C functions removed: `tableGenRecordValGetValAsRecord` (never implemented), `tableGenBitsInitGetValue` (used `reinterpret_cast<BitInit*>` without a `dyn_cast` guard), and `tableGenBitArrayFree` / `tableGenRecordValGetValAsBits` which depended on it.

The `RecordKeeper` class and def iterators are fixed: the old `end()` derivation navigated back through the record to call `getClasses().end()` / `getDefs().end()` on each advance, which was fragile. Replaced the raw `RecordMap::const_iterator*` with a `RecordMapIterator` struct that carries both `it` and `end`.

New API: `Record::template_args()`, `Record::direct_super_classes()` (LLVM >= 21 guarded), `RecordKeeper::all_derived_definitions_if_defined()`, and `ListInit::element_type()`. All new iterators implement `DoubleEndedIterator + ExactSizeIterator + FusedIterator`. 12 new tests added, 43 total pass.