### PR TITLE
Bump version to 0.8.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tblgen"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Daan Vanoverloop", "Yota Toyama", "Edgar Luque"]


### PR DESCRIPTION
## Summary
- Bump crate version from 0.8.0 to 0.8.1

Follows #55 which added fixes and new API coverage.