### PR TITLE
Fix docs deployment branch condition (master -> main)

### DIFF
--- a/.github/workflows/document.yaml
+++ b/.github/workflows/document.yaml
@@ -21,4 +21,4 @@ jobs:
         with:
           path: target/doc
       - uses: actions/deploy-pages@v4
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
The `deploy-pages` step in `.github/workflows/document.yaml` was gated on `refs/heads/master`. Docs were built on every push to `main` but never deployed, leaving the published docs stuck at 0.6.0. Changed the condition to `refs/heads/main`.